### PR TITLE
Release v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "github-actions-test",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@angular/animations": "~11.1.0",
         "@angular/common": "~11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions-test",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Now the release workflow should work vor v0.3.0 because the tag exists and (git push origin --tags is done) and the package.json version is set to the same.