### PR TITLE
try to allow push tag later if it is in master

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -8,6 +8,9 @@ on:
     types: [closed]
     branches:
       - main
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]"
 
 jobs:
   # Check if the latest git Tag is the same as the repo npm version
@@ -27,7 +30,7 @@ jobs:
 
   test:
     needs: checkTags
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || git branch --contains $(git rev-parse GITHUB_REF:10) | grep '^github/master$'
     runs-on: ubuntu-latest
     steps:
       # check out before using actions reference from the same repository!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "github-actions-test",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@angular/animations": "~11.1.0",
         "@angular/common": "~11.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions-test",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Now if a tag in is pushed after the pull request was closed, main-release should be triggered and try to check if the tag is already in the master.